### PR TITLE
Checking full_audit value instead of existence

### DIFF
--- a/Humpback/Parts/SQLServerFormatter.cs
+++ b/Humpback/Parts/SQLServerFormatter.cs
@@ -292,7 +292,7 @@ namespace Humpback.Parts {
                 var columns = BuildColumnList(op.create_table.name, op.create_table.columns);
 
                 //add some timestamps?
-                if (op.create_table.full_audit != null) {
+                if (op.create_table.full_audit ?? false) {
                     columns += sql_fs_FullAudit;
                 } else if (op.create_table.timestamps != null) {
                     columns += sql_fs_Timestamps;


### PR DESCRIPTION
I saw that a migration with the full_audit value set to false was still crating the timestamp columns

{
	"up":{
		"create_table":{
			"name":"Test1","full_audit":false, <---- timestamp columns still added
			"columns":[{
			"name":"Name","type":"string"}]
		}
	},
	"down":{
		"drop_table":"Test1"}}